### PR TITLE
An alternative version of find_node_tip_weights

### DIFF
--- a/tsdate/__init__.py
+++ b/tsdate/__init__.py
@@ -22,7 +22,7 @@
 
 from .age_inference import (  # NOQA
     age_inference, restrict_ages_topo, return_ts,
-    find_node_tip_weights_ts, make_prior, get_mixture_prior_ts_new)
+    find_node_tip_weights, make_prior, get_mixture_prior_ts_new)
 
 
 from .provenance import __version__  # NOQA


### PR DESCRIPTION
(also renamed). This should be faster, as it doesn't iterate through all nodes for all trees, but iterates over trees first and only iterates over the nodes *in that tree*. There is a faster way, however, as described in the comments (also see https://github.com/tskit-dev/tskit/issues/360)