### PR TITLE
Check we do not allow noncontemporaneous samples

### DIFF
--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -67,6 +67,16 @@ class TestSimulated(unittest.TestCase):
         dated_ts = tsdate.date(ts, Ne=1, mutation_rate=5)
         self.ts_equal_except_times(ts, dated_ts)
 
+    def test_non_contemporaneous(self):
+        samples = [
+            msprime.Sample(population=0, time=0),
+            msprime.Sample(population=0, time=0),
+            msprime.Sample(population=0, time=0),
+            msprime.Sample(population=0, time=1.0)
+        ]
+        ts = msprime.simulate(samples=samples, Ne=1, mutation_rate=2)
+        self.assertRaises(NotImplementedError, tsdate.date, ts, 1, 2)
+
     @unittest.skip("Truncated sequences not currently accounted for")
     def test_truncated_ts(self):
         Ne = 1e2

--- a/tsdate/date.py
+++ b/tsdate/date.py
@@ -430,6 +430,11 @@ def date(
         raise NotImplementedError(
             "Using multiple threads is not yet implemented")
 
+    for sample in tree_sequence.samples():
+        if tree_sequence.node(sample).time != 0:
+            raise NotImplementedError(
+                "Samples must all be at time 0")
+
     tip_weights = find_node_tip_weights(tree_sequence)
     prior = make_prior(tree_sequence.num_samples, Ne)
 


### PR DESCRIPTION
As discussed in #18 