### PR TITLE
Create a class to abstract the lower triangular L matrix

### DIFF
--- a/tests/utility_functions.py
+++ b/tests/utility_functions.py
@@ -188,16 +188,17 @@ def single_tree_ts_with_unary():
 
 def two_tree_mutation_ts():
     r"""
-    Simple case where we have n = 3, 2 trees, two mutations.
-                     .    5
-                     .   / \
-            4        .  |   4
-           / \       .  |   |\
-          x   \      .  |   | \
-          |    \     .  x   |  \
-          3     \    .  |   |   \
-         / \     \   .  |   |    \
-        0   1     2  .  0   1     2
+    Simple case where we have n = 3, 2 trees, three mutations.
+                   .     5
+                   .    / \
+            4      .   |   4
+           / \     .   |   |\
+          x   \    .   |   | \
+         x     \   .   x   |  \
+        /      |   .   |   |   |
+       3       |   .   |   |   |
+      / \      |   .   |   |   |
+     0   1     2   .   0   1   2
     """
     nodes = io.StringIO("""\
     id      is_sample   time
@@ -219,12 +220,14 @@ def two_tree_mutation_ts():
     sites = io.StringIO("""\
     position    ancestral_state
     0.1         0
+    0.15         0
     0.8         0
     """)
     mutations = io.StringIO("""\
     site    node    derived_state
     0       3       1
-    1       0       1
+    1       3       1
+    2       0       1
     """)
     return tskit.load_text(nodes=nodes, edges=edges, sites=sites,
                            mutations=mutations, strict=False)

--- a/tsdate/__init__.py
+++ b/tsdate/__init__.py
@@ -22,9 +22,9 @@
 
 from .date import (  # NOQA
     date, restrict_ages_topo, return_ts, create_time_grid,
-    get_prior_values, forward_algorithm, ConditionalCoalescentTimes, SpansBySamples,
+    get_prior_values, upward_algorithm, ConditionalCoalescentTimes, SpansBySamples,
     posterior_mean_var, gamma_approx, get_mixture_prior, iterate_parent_edges,
-    backward_algorithm, get_mut_ll, LowerTriangularMatrix)
+    downward_algorithm, Likelihoods)
 
 
 from .provenance import __version__  # NOQA


### PR DESCRIPTION
This seems to pass the test but still complains about "date.py:1079: RuntimeWarning: divide by zero encountered in log  log_backwards = np.log(backwards)" - it might do some more than it used to, as I removed some of the (probably needless) stuff in the normalisation of the backwards (i.e., I simply omitted backwards[X, 0] from all normalisation. I guess this is OK, but maybe you could check that I haven't messed up, @awohns ? And also that the changes make sense, and the new methods are named sensibly (I suspect some like `expand_forwards` could do with better names)