### PR TITLE
Only tally fixed nodes for prior if at time 0

### DIFF
--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -662,7 +662,7 @@ class TestUpwardAlgorithm(unittest.TestCase):
 class TestDownwardAlgorithm(unittest.TestCase):
     def run_downward_algorithm(self, ts):
         span_data = tsdate.SpansBySamples(ts)
-        spans = span_data.node_total_span
+        spans = span_data.node_spans
         priors = tsdate.ConditionalCoalescentTimes(None)
         priors.add(ts.num_samples, approximate=False)
         grid = np.array([0, 1.2, 2])


### PR DESCRIPTION
This seems pretty clear, and obvious to merge. No tests for non-contemporaneous samples yet, though...