### PR TITLE
Revert unneeded node time change

### DIFF
--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -164,9 +164,9 @@ class TestNodeTipWeights(unittest.TestCase):
         n = ts.num_samples
         span_data = self.verify_weights(ts)
         self.assertEqual(span_data.lookup_weight(7, n, 3), 1.0)
-        self.assertEqual(span_data.lookup_weight(6, n, 2), 0.5)
+        self.assertEqual(span_data.lookup_weight(6, n, 1), 0.5)
         self.assertEqual(span_data.lookup_weight(6, n, 3), 0.5)
-        self.assertEqual(span_data.lookup_weight(5, n, 1), 0.5)
+        self.assertEqual(span_data.lookup_weight(5, n, 2), 0.5)
         self.assertEqual(span_data.lookup_weight(5, n, 3), 0.5)
         self.assertEqual(span_data.lookup_weight(4, n, 2), 0.75)
         self.assertEqual(span_data.lookup_weight(4, n, 3), 0.25)
@@ -418,12 +418,12 @@ class TestMixturePrior(unittest.TestCase):
         # Root is a 3 tip prior
         self.assertTrue(
             np.allclose(mixture_prior[7, self.alpha_beta], [1.6, 1.2]))
-        # Node 6 should be a 50:50 mixture of 2 and 3 tips
+        # Node 6 should be a 50:50 mixture between 1 and 3 tips
         self.assertTrue(
-            np.allclose(mixture_prior[6, self.alpha_beta], [0.80645, 0.96774]))
-        # Node 5 should be a 50:50 mixture between 1 and 3 tips
+            np.allclose(mixture_prior[6, self.alpha_beta], [0.44444, 0.66666]))
+        # Node 5 should be a 50:50 mixture of 2 and 3 tips
         self.assertTrue(
-            np.allclose(mixture_prior[5, self.alpha_beta], [0.44444, 0.66666]))
+            np.allclose(mixture_prior[5, self.alpha_beta], [0.80645, 0.96774]))
         # Node 4 should be a 75:25 mixture of 2 and 3 tips
         self.assertTrue(
             np.allclose(mixture_prior[4, self.alpha_beta], [0.62025, 1.06329]))
@@ -489,8 +489,8 @@ class TestPriorVals(unittest.TestCase):
         ts = utility_functions.single_tree_ts_with_unary()
         prior_vals = self.verify_prior_vals(ts, 'gamma')
         self.assertTrue(np.allclose(prior_vals[7], [0, 1, 0.397385]))
-        self.assertTrue(np.allclose(prior_vals[6], [0, 1, 0.164433]))
-        self.assertTrue(np.allclose(prior_vals[5], [0, 1, 0.113122]))
+        self.assertTrue(np.allclose(prior_vals[6], [0, 1, 0.113122]))
+        self.assertTrue(np.allclose(prior_vals[5], [0, 1, 0.164433]))
         self.assertTrue(np.allclose(prior_vals[4], [0, 1, 0.093389]))
         self.assertTrue(np.allclose(prior_vals[3], [0, 1, 0.011109]))
 
@@ -882,8 +882,8 @@ class TestInsideAlgorithm(unittest.TestCase):
         ts = utility_functions.single_tree_ts_with_unary()
         algo = self.run_inside_algorithm(ts, 'gamma')[0]
         self.assertTrue(np.allclose(algo.inside[7], np.array([0, 1, 0.25406637])))
-        self.assertTrue(np.allclose(algo.inside[6], np.array([0, 1, 0.13189998])))
-        self.assertTrue(np.allclose(algo.inside[5], np.array([0, 1, 0.07506923])))
+        self.assertTrue(np.allclose(algo.inside[6], np.array([0, 1, 0.07506923])))
+        self.assertTrue(np.allclose(algo.inside[5], np.array([0, 1, 0.13189998])))
         self.assertTrue(np.allclose(algo.inside[4], np.array([0, 1, 0.07370801])))
         self.assertTrue(np.allclose(algo.inside[3], np.array([0, 1, 0.01147716])))
 

--- a/tests/utility_functions.py
+++ b/tests/utility_functions.py
@@ -318,9 +318,9 @@ def single_tree_ts_with_unary():
     Simple case where we have n = 3 and some unary nodes.
             7
            / \
-          6   \
+          5   \
           |    \
-          4     5
+          4     6
           |     |
           3     |
          / \    |
@@ -333,16 +333,16 @@ def single_tree_ts_with_unary():
     2       1           0
     3       0           1
     4       0           2
-    5       0           2
-    6       0           3
+    5       0           3
+    6       0           2
     7       0           4
     """)
     edges = io.StringIO("""\
     left    right   parent  child
     0       1       3       0,1
-    0       1       5       2
+    0       1       6       2
     0       1       4       3
-    0       1       6       4
+    0       1       5       4
     0       1       7       5,6
     """)
     return tskit.load_text(nodes=nodes, edges=edges, strict=False)


### PR DESCRIPTION
This reverts the alterations made to place the nodes in the unary_node_example in time order. It isn't a requirement of a tree seq for the nodes to be in time order, so we should be able to deal with it without outputting the wrong error message. It's probably worth reverting the changes as it's a better test of whether dangling & unary nodes are properly detected (which now, I hope they are)