### PR TITLE
Support for keep_intervals and delete_intervals

### DIFF
--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -199,17 +199,17 @@ class TestNodeTipWeights(unittest.TestCase):
         ts = utility_functions.single_tree_ts_n2()
         deleted_interval_ts = ts.delete_intervals([[0.5, 0.6]])
         n = deleted_interval_ts.num_samples
-        span_data = self.verify_weights(ts) 
-        span_data_deleted = self.verify_weights(deleted_interval_ts) 
+        span_data = self.verify_weights(ts)
+        span_data_deleted = self.verify_weights(deleted_interval_ts)
         self.assertEqual(span_data.lookup_weight(2, n, 2),
-                         span_data_deleted.lookup_weight(2, n , 2))
+                         span_data_deleted.lookup_weight(2, n, 2))
 
     def test_single_tree_n4_delete_intervals(self):
         ts = utility_functions.single_tree_ts_n4()
         deleted_interval_ts = ts.delete_intervals([[0.5, 0.6]])
         n = deleted_interval_ts.num_samples
-        span_data = self.verify_weights(ts) 
-        span_data_deleted = self.verify_weights(deleted_interval_ts) 
+        span_data = self.verify_weights(ts)
+        span_data_deleted = self.verify_weights(deleted_interval_ts)
         self.assertEqual(span_data.lookup_weight(4, n, 2),
                          span_data_deleted.lookup_weight(4, n, 2))
         self.assertEqual(span_data.lookup_weight(5, n, 3),
@@ -221,9 +221,9 @@ class TestNodeTipWeights(unittest.TestCase):
         ts = utility_functions.two_tree_ts()
         deleted_interval_ts = ts.delete_intervals([[0.5, 0.6]])
         n = deleted_interval_ts.num_samples
-        span_data = self.verify_weights(ts) 
-        span_data_deleted = self.verify_weights(deleted_interval_ts) 
-        self.assertEqual(span_data.lookup_weight(3, n, 2), 
+        span_data = self.verify_weights(ts)
+        span_data_deleted = self.verify_weights(deleted_interval_ts)
+        self.assertEqual(span_data.lookup_weight(3, n, 2),
                          span_data_deleted.lookup_weight(3, n, 2))
         self.assertAlmostEqual(
             span_data_deleted.lookup_weight(4, n, 2)[0], 0.7 / 0.9)
@@ -467,7 +467,7 @@ class TestMixturePrior(unittest.TestCase):
                     tests.append(np.allclose(
                         mix_priors[internal_node, self.alpha_beta],
                         mix_priors_ints[internal_node, self.alpha_beta]))
-        return tests 
+        return tests
 
     def test_one_tree_n2_intervals(self):
         ts = utility_functions.single_tree_ts_n2()

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -58,6 +58,19 @@ class TestPrebuilt(unittest.TestCase):
                 NotImplementedError, tsdate.date, ts, Ne=1, recombination_rate=1,
                 probability_space=probability_space, mutation_rate=1)
 
+    def test_intervals(self):
+        ts = utility_functions.two_tree_ts()
+        long_ts = utility_functions.two_tree_ts_extra_length()
+        keep_ts = long_ts.keep_intervals([[0., 1.]])
+        delete_ts = long_ts.delete_intervals([[1., 1.5]])
+        dated_ts = tsdate.date(ts, Ne=1)
+        dated_keep_ts = tsdate.date(keep_ts, Ne=1) 
+        dated_deleted_ts = tsdate.date(delete_ts, Ne=1)
+        self.assertTrue(np.allclose(dated_ts.tables.nodes.time[:],
+                                    dated_keep_ts.tables.nodes.time[:]))
+        self.assertTrue(np.allclose(dated_ts.tables.nodes.time[:],
+                                    dated_deleted_ts.tables.nodes.time[:]))
+
 #     def test_simple_ts_n2(self):
 #         ts = utility_functions.single_tree_ts_n2()
 #         dated_ts = tsdate.date(ts, Ne=10000)

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -64,7 +64,7 @@ class TestPrebuilt(unittest.TestCase):
         keep_ts = long_ts.keep_intervals([[0., 1.]])
         delete_ts = long_ts.delete_intervals([[1., 1.5]])
         dated_ts = tsdate.date(ts, Ne=1)
-        dated_keep_ts = tsdate.date(keep_ts, Ne=1) 
+        dated_keep_ts = tsdate.date(keep_ts, Ne=1)
         dated_deleted_ts = tsdate.date(delete_ts, Ne=1)
         self.assertTrue(np.allclose(dated_ts.tables.nodes.time[:],
                                     dated_keep_ts.tables.nodes.time[:]))

--- a/tests/utility_functions.py
+++ b/tests/utility_functions.py
@@ -314,6 +314,38 @@ def two_tree_ts():
     return tskit.load_text(nodes=nodes, edges=edges, strict=False)
 
 
+def two_tree_ts_extra_length():
+    r"""
+    Simple case where we have n = 3 and 2 trees, but with extra length
+    for testing keep_intervals() and delete_intervals().
+                   .    5
+                   .   / \
+            4      .  |   4
+           / \     .  |   |\
+          3   \    .  |   | \
+         / \   \   .  |   |  \
+       [0] [1] [2] . [0] [1] [2]
+    """
+    nodes = io.StringIO("""\
+    id      is_sample   time
+    0       1           0
+    1       1           0
+    2       1           0
+    3       0           1
+    4       0           2
+    5       0           3
+    """)
+    edges = io.StringIO("""\
+    left    right   parent  child
+    0       0.2     3       0,1
+    0       1.5     4       2
+    0       0.2     4       3
+    0.2     1.5     4       1
+    0.2     1.5     5       0,4
+    """)
+    return tskit.load_text(nodes=nodes, edges=edges, strict=False)
+
+
 def two_tree_ts_n3_non_contemporaneous():
     r"""
     Simple case where we have n = 3 and two trees with node 2 ancient.

--- a/tsdate/prior.py
+++ b/tsdate/prior.py
@@ -967,7 +967,8 @@ def build_grid(tree_sequence, timepoints=20, *, approximate_priors=False,
     base_priors.add(contmpr_ts.num_samples, approximate_priors)
     for total_fixed in span_data.total_fixed_at_0_counts:
         # For missing data: trees vary in total fixed node count => have different priors
-        base_priors.add(total_fixed, approximate_priors)
+        if total_fixed > 0:
+            base_priors.add(total_fixed, approximate_priors)
 
     if isinstance(timepoints, int):
         if timepoints < 2:


### PR DESCRIPTION
One line change to support the tree sequences that result from a call to keep_intervals() or delete_intervals().

Tests to show that the priors are unchanged.

NOTE: the resulting date estimates will be different with _any_ deletion of an internal interval. The test "test_intervals()" in tests/test_inference.py() demonstrates this. If we take an internal interval in the two_tree_ts_extra_long() of [0.5, 1.0], the resulting dates will be different than the results of tsdate on two_tree_ts(). I think this is expected. 