### PR TITLE
Support for ancient samples

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,6 +4,9 @@
 Welcome to tsdate's documentation
 ==================================
 
+This is the documentation for ``tsdate``, a method for efficiently inferring the
+age of ancestors in a tree sequence.
+
 .. toctree::
    :maxdepth: 2
    :caption: Contents:

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -22,10 +22,11 @@
 """
 Test cases for the python API for tsdate.
 """
+import json
 import unittest
 
+import attr
 import numpy as np
-import tskit
 import msprime
 import tsinfer
 
@@ -131,25 +132,32 @@ class TestSimulated(unittest.TestCase):
     Tests for tsdate on simulated tree sequences.
     """
     def ts_equal_except_times(self, ts1, ts2):
-        for (_, t1), (_, t2) in zip(ts1.tables, ts2.tables):
-            if isinstance(t1, tskit.ProvenanceTable):
-                # TO DO - should check that the provenance has had the "tsdate" method
-                # added
-                pass
-            elif isinstance(t1, tskit.NodeTable):
-                # Dated tree sequence will have metadata added for unconstrained times
-                for column_name in t1.column_names:
-                    if column_name not in ["time", "metadata", "metadata_offset"]:
-                        col_t1 = getattr(t1, column_name)
-                        col_t2 = getattr(t2, column_name)
-                        self.assertTrue(np.array_equal(col_t1, col_t2))
-            elif isinstance(t1, tskit.EdgeTable):
-                # Edges may have been re-ordered, since sortedness requirements specify
-                # they are sorted by parent time, and the relative order of
-                # (unconnected) parent nodes might have changed due to time inference
-                self.assertEquals(set(t1), set(t2))
-            else:
-                self.assertEquals(t1, t2)
+        self.assertEqual(ts1.sequence_length, ts2.sequence_length)
+        t1 = ts1.tables
+        t2 = ts2.tables
+        self.assertEqual(t1.sites, t2.sites)
+        self.assertEqual(t1.mutations, t2.mutations)
+        # Edges may have been re-ordered, since sortedness requirements specify
+        # they are sorted by parent time, and the relative order of
+        # (unconnected) parent nodes might have changed due to time inference
+        self.assertEquals(set(t1.edges), set(t2.edges))
+        # The dated and undated tree sequences should not have the same node times
+        self.assertTrue(not np.array_equal(
+            ts1.tables.nodes.time, ts2.tables.nodes.time))
+        # New tree sequence will have node times in metadata
+        for column_name in t1.nodes.column_names:
+            if column_name not in ["time", "metadata", "metadata_offset"]:
+                col_t1 = getattr(t1.nodes, column_name)
+                col_t2 = getattr(t2.nodes, column_name)
+                self.assertTrue(np.array_equal(col_t1, col_t2))
+        # Assert that last provenance shows tree sequence was dated
+        self.assertEqual(len(t1.provenances), len(t2.provenances) - 1)
+        for index, (prov1, prov2) in enumerate(zip(t1.provenances, t2.provenances)):
+            self.assertEqual(prov1, prov2)
+            if index == len(t1.provenances) - 1:
+                break
+        self.assertEqual(
+                json.loads(t2.provenances[-1].record)["software"]["name"], "tsdate")
 
     def test_simple_sim_1_tree(self):
         ts = msprime.simulate(8, mutation_rate=5, random_seed=2)
@@ -209,7 +217,7 @@ class TestSimulated(unittest.TestCase):
             if row.parent not in tree.roots and row.child not in ts.samples():
                 if not internal_edge_removed:
                     continue
-            tables.edges.add_row(*row)
+            tables.edges.add_row(**attr.asdict(row))
         multiroot_ts = tables.tree_sequence()
         good_priors = tsdate.build_prior_grid(ts)
         self.assertRaises(ValueError, tsdate.build_prior_grid, multiroot_ts)
@@ -250,7 +258,8 @@ class TestInferred(unittest.TestCase):
     def test_simple_sim_1_tree(self):
         ts = msprime.simulate(8, mutation_rate=5, random_seed=2)
         for use_times in [True, False]:
-            sample_data = tsinfer.SampleData.from_tree_sequence(ts, use_times=use_times)
+            sample_data = tsinfer.SampleData.from_tree_sequence(
+                    ts, use_sites_time=use_times)
             inferred_ts = tsinfer.infer(sample_data)
             max_dated_ts = tsdate.date(inferred_ts, Ne=1, mutation_rate=5,
                                        method="maximization")
@@ -265,7 +274,8 @@ class TestInferred(unittest.TestCase):
         ts = msprime.simulate(8, mutation_rate=5, recombination_rate=5, random_seed=2)
         self.assertGreater(ts.num_trees, 1)
         for use_times in [True, False]:
-            sample_data = tsinfer.SampleData.from_tree_sequence(ts, use_times=use_times)
+            sample_data = tsinfer.SampleData.from_tree_sequence(
+                    ts, use_sites_time=use_times)
             inferred_ts = tsinfer.infer(sample_data)
             max_dated_ts = tsdate.date(inferred_ts, Ne=1, mutation_rate=5,
                                        method="maximization")

--- a/tests/utility_functions.py
+++ b/tests/utility_functions.py
@@ -152,6 +152,36 @@ def single_tree_ts_mutation_n3():
                            mutations=mutations, strict=False)
 
 
+def site_no_mutations():
+    r"""
+    Simple case where we have n = 3 and one tree.
+    The single mutation has no derived alleles.
+            4
+           / \
+          3   x
+         / \   \
+       [0] [1] [2]
+    """
+    nodes = io.StringIO("""\
+    id      is_sample   time
+    0       1           0
+    1       1           0
+    2       1           0
+    3       0           1
+    4       0           2
+    """)
+    edges = io.StringIO("""\
+    left    right   parent  child
+    0       1       3       0,1
+    0       1       4       2,3
+    """)
+    sites = io.StringIO("""\
+    position    ancestral_state
+    0.5         0
+    """)
+    return tskit.load_text(nodes=nodes, edges=edges, sites=sites, strict=False)
+
+
 def single_tree_all_samples_one_mutation_n3():
     r"""
     Simple case where we have n = 3 and one tree.
@@ -605,14 +635,122 @@ def two_tree_ts_n2_part_dangling():
     return tskit.load_text(nodes=nodes, edges=edges, strict=False)
 
 
-def ts_w_data_desert(gap_start, gap_end):
+def single_tree_ts_2mutations_multiallelic_n3():
+    r"""
+    Simple case where we have n = 3 and one tree.
+    Site is multiallelic.
+            4
+           x \
+          3   x
+         / \   \
+       [0] [1] [2]
+    """
+    nodes = io.StringIO("""\
+    id      is_sample   time
+    0       1           0
+    1       1           0
+    2       1           0
+    3       0           1
+    4       0           2
+    """)
+    edges = io.StringIO("""\
+    left    right   parent  child
+    0       1       3       0,1
+    0       1       4       2,3
+    """)
+    sites = io.StringIO("""\
+    position    ancestral_state
+    0.5         0
+    """)
+    mutations = io.StringIO("""\
+    site    node    derived_state
+    0       2       1
+    0       3       2
+    """)
+    return tskit.load_text(nodes=nodes, edges=edges, sites=sites,
+                           mutations=mutations, strict=False)
+
+
+def single_tree_ts_2mutations_singletons_n3():
+    r"""
+    Simple case where we have n = 3 and one tree.
+    Site has two singleton mutations.
+            4
+           / \
+          3   x
+         / x   \
+       [0] [1] [2]
+    """
+    nodes = io.StringIO("""\
+    id      is_sample   time
+    0       1           0
+    1       1           0
+    2       1           0
+    3       0           1
+    4       0           2
+    """)
+    edges = io.StringIO("""\
+    left    right   parent  child
+    0       1       3       0,1
+    0       1       4       2,3
+    """)
+    sites = io.StringIO("""\
+    position    ancestral_state
+    0.5         0
+    """)
+    mutations = io.StringIO("""\
+    site    node    derived_state
+    0       1       1
+    0       2       1
+    """)
+    return tskit.load_text(nodes=nodes, edges=edges, sites=sites,
+                           mutations=mutations, strict=False)
+
+
+def single_tree_ts_2mutations_n3():
+    r"""
+    Simple case where we have n = 3 and one tree.
+    Site has two mutations with different times.
+            4
+           x \
+          3   \
+         / x   \
+       [0] [1] [2]
+    """
+    nodes = io.StringIO("""\
+    id      is_sample   time
+    0       1           0
+    1       1           0
+    2       1           0
+    3       0           1
+    4       0           2
+    """)
+    edges = io.StringIO("""\
+    left    right   parent  child
+    0       1       3       0,1
+    0       1       4       2,3
+    """)
+    sites = io.StringIO("""\
+    position    ancestral_state
+    0.5         0
+    """)
+    mutations = io.StringIO("""\
+    site    node    derived_state
+    0       1       1
+    0       3       1
+    """)
+    return tskit.load_text(nodes=nodes, edges=edges, sites=sites,
+                           mutations=mutations, strict=False)
+
+
+def ts_w_data_desert(gap_start, gap_end, length):
     """
     Inside/Outside algorithm has been observed to give overflow/underflow when
     attempting to date tree sequences with large regions without data. Test
     that preprocess_ts removes regions of a specified size that have no data.
     """
     ts = msprime.simulate(
-            100, mutation_rate=10, recombination_rate=1, length=10)
+            100, mutation_rate=10, recombination_rate=1, length=length)
     tables = ts.dump_tables()
     sites = tables.sites.position[:]
     tables.delete_sites(np.where(np.logical_and(sites > gap_start, sites < gap_end))[0])

--- a/tsdate/__init__.py
+++ b/tsdate/__init__.py
@@ -23,6 +23,6 @@
 
 from .date import date # NOQA
 from .prior import build_grid as build_prior_grid # NOQA
-from .util import preprocess_ts # NOQA
+from .util import preprocess_ts, sites_time_from_ts, add_sampledata_times # NOQA
 from .provenance import __version__ # NOQA
 from .cache import * # NOQA

--- a/tsdate/base.py
+++ b/tsdate/base.py
@@ -31,6 +31,10 @@ FLOAT_DTYPE = np.float64
 LIN = "linear"
 LOG = "logarithmic"
 
+# Bit 20 is set in node flags when they are samples not at time zero in the sampledata
+# file
+NODE_IS_HISTORIC_SAMPLE = 1 << 20
+
 
 class NodeGridValues:
     """

--- a/tsdate/date.py
+++ b/tsdate/date.py
@@ -677,7 +677,7 @@ class InOutAlgorithms:
         self.outside = outside
         return posterior
 
-    def outside_maximization(self, *, eps=1e-6, progress=None):
+    def outside_maximization(self, Ne, *, eps, progress=None):
         if progress is None:
             progress = self.progress
         if not hasattr(self, "inside"):
@@ -730,17 +730,18 @@ class InOutAlgorithms:
             maximized_node_times[child] = np.argmax(self.lik.combine(
                 result[:youngest_par_index + 1], inside_val))
 
-        return self.lik.timepoints[np.array(maximized_node_times).astype('int')]
+        return (self.lik.timepoints[np.array(maximized_node_times).astype('int')] * 2
+                * Ne)
 
 
-def posterior_mean_var(ts, timepoints, posterior, *, fixed_node_set=None):
+def posterior_mean_var(ts, timepoints, posterior, Ne, *, fixed_node_set=None):
     """
     Mean and variance of node age in scaled time. Fixed nodes will be given a mean
     of their exact time in the tree sequence, and zero variance (as long as they are
     identified by the fixed_node_set
     If fixed_node_set is None, we attempt to date all the non-sample nodes
-    Also assigns the estimated mean and variance of each node as metadata in the tree
-    sequence.
+    Also assigns the estimated mean and variance of the age of each node, in unscaled
+    time, as metadata in the tree sequence.
     """
     mn_post = np.full(ts.num_nodes, np.nan)  # Fill with NaNs so we detect when there's
     vr_post = np.full(ts.num_nodes, np.nan)  # been an error
@@ -754,11 +755,11 @@ def posterior_mean_var(ts, timepoints, posterior, *, fixed_node_set=None):
 
     metadata_array = tskit.unpack_bytes(ts.tables.nodes.metadata,
                                         ts.tables.nodes.metadata_offset)
-
+    timepoints = timepoints * 2 * Ne
     for row, node_id in zip(posterior.grid_data, posterior.nonfixed_nodes):
         mn_post[node_id] = np.sum(row * timepoints) / np.sum(row)
-        vr_post[node_id] = (np.sum(row * timepoints ** 2) / np.sum(row) -
-                            mn_post[node_id] ** 2)
+        vr_post[node_id] = np.sum(((
+            mn_post[node_id] - (timepoints)) ** 2) * (row / np.sum(row)))
         metadata_array[node_id] = json.dumps({"mn": mn_post[node_id],
                                               "vr": vr_post[node_id]}).encode()
     md, md_offset = tskit.pack_bytes(metadata_array)
@@ -846,7 +847,7 @@ def date(
     constrained = constrain_ages_topo(tree_sequence, dates, eps, nds,
                                       progress)
     tables = tree_sequence.dump_tables()
-    tables.nodes.time = constrained * 2 * Ne
+    tables.nodes.time = constrained
     tables.sort()
     ts = tables.tree_sequence()
     return provenance.record_provenance(
@@ -910,10 +911,11 @@ def get_dates(
     if method == 'inside_outside':
         posterior = dynamic_prog.outside_pass(normalize=outside_normalize)
         tree_sequence, mn_post, _ = posterior_mean_var(
-                tree_sequence, priors.timepoints, posterior, fixed_node_set=fixed_nodes)
+                tree_sequence, priors.timepoints, posterior, Ne,
+                fixed_node_set=fixed_nodes)
     elif method == 'maximization':
         if theta is not None:
-            mn_post = dynamic_prog.outside_maximization(eps=eps)
+            mn_post = dynamic_prog.outside_maximization(Ne, eps=eps)
         else:
             raise ValueError("Outside maximization method requires mutation rate")
     else:


### PR DESCRIPTION
Adds two functions to support the inference of tree sequences from modern and ancient samples. The first is `sites_time`: a function to retrieve the times associated with each variable site, optionally using the unconstrained age estimates from the Inside-Outside algorithm of `tsdate`. The second function is `add_sites_time`: a wrapper for a few `tsinfer` and `tsdate` functions which adds ages to the SampleData.sites_time Zarr array. 

Also adds a tutorial which shows how to perform such inference. 